### PR TITLE
User's can Delete a Payment Type

### DIFF
--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -32,7 +32,7 @@ namespace Bangazon.Controllers
         // GET: PaymentTypes
         [Authorize]
         //constructor type of paymenttype
-        public async Task<IActionResult> Index(PaymentType PaymentType)
+        public async Task<IActionResult> Index()
         {
             var applicationDbContext = _context.PaymentType.Include(p => p.User);
 
@@ -190,20 +190,31 @@ namespace Bangazon.Controllers
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
-        {
+        {   
+            //gets the payment type by id
             PaymentType paymentType = await _context.PaymentType.FindAsync(id);
+
+            
             try
             {
-               
+               //it first tries to remove the payment type from the data base
                 _context.PaymentType.Remove(paymentType);
+                //then save the changes
                 await _context.SaveChangesAsync();
             }
+            // if the payment type is associated with an order
+            // this catches the exception when it's active
             catch (Exception) when (paymentType.Active == true)
             {
+                //changes the active status to false
                 paymentType.Active = false;
+                //updates the payment type since it cant be deleted
                 _context.Update(paymentType);
+                //saves the changes
                 await _context.SaveChangesAsync();
             }
+
+            // redirects back to the view of all payment types
             return RedirectToAction(nameof(Index));
         }
 

--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -20,10 +20,8 @@ namespace Bangazon.Controllers
 
         private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
 
-        public interface IIsDeleted
-{
-    bool IsDeleted { get; set; }
-}
+       
+
 
         public PaymentTypesController(ApplicationDbContext context, UserManager<ApplicationUser> userManager)
         {
@@ -33,24 +31,29 @@ namespace Bangazon.Controllers
 
         // GET: PaymentTypes
         [Authorize]
+        //constructor type of paymenttype
         public async Task<IActionResult> Index(PaymentType PaymentType)
         {
             var applicationDbContext = _context.PaymentType.Include(p => p.User);
 
             var user = await GetCurrentUserAsync();
 
-            var userCheck = await _context.PaymentType.Where(p => p.UserId == user.Id).ToListAsync();
+            //gets all payment types associated with the user and has and active status of true
+            //returns that information to a list
+            var userCheck = await _context.PaymentType.Where(p => p.UserId == user.Id && p.Active == true).ToListAsync();
 
             // if there are 0 payment types assocated with the user
-            if (userCheck.Count() < 1 || PaymentType.Active == false)
+            // or if their or no active payment types
+            if (userCheck.Count() < 1 )
             {
-                //if the user has no payment types associated with them redirect to a page that tells them that
+                //redirect to a page that tells them 
                 //and gives them an option to create a payment type
                 return View("NoPaymentTypes");
             }
 
-            //returns a view that hass all payment types associated with the user
             return View(userCheck);
+                //returns a view that hass all payment types associated with the user
+               
         }
 
         // GET: PaymentTypes/Details/5
@@ -98,7 +101,7 @@ namespace Bangazon.Controllers
                 var user = await GetCurrentUserAsync();
                 //grabs the current user's id
                 paymentType.UserId = user.Id;
-                //sets the active status to true
+                //sets the active status to true anytime a new payment type is created
                 paymentType.Active = true;
                 //adds all the user and paymentType information into context
                 _context.Add(paymentType);

--- a/Bangazon/Models/PaymentType.cs
+++ b/Bangazon/Models/PaymentType.cs
@@ -31,6 +31,6 @@ namespace Bangazon.Models
     public ApplicationUser User { get; set; }
 
     public ICollection<Order> Orders { get; set; }
-        public bool Active { get; set; }
+    public bool Active { get; set; }
     }
 }

--- a/Bangazon/Views/PaymentTypes/Create.cshtml
+++ b/Bangazon/Views/PaymentTypes/Create.cshtml
@@ -22,12 +22,8 @@
                 <input asp-for="AccountNumber" class="form-control" />
                 <span asp-validation-for="AccountNumber" class="text-danger"></span>
             </div>
-      
-            <div class="form-group form-check">
-                <label class="form-check-label">
-                    <input class="form-check-input" asp-for="Active" /> @Html.DisplayNameFor(model => model.Active)
-                </label>
-            </div>
+
+        
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />
             </div>

--- a/Bangazon/Views/PaymentTypes/Delete.cshtml
+++ b/Bangazon/Views/PaymentTypes/Delete.cshtml
@@ -29,18 +29,7 @@
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.AccountNumber)
         </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.User)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.User.Id)
-        </dd class>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Active)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Active)
-        </dd>
+ 
     </dl>
     
     <form asp-action="Delete">

--- a/Bangazon/Views/PaymentTypes/Index.cshtml
+++ b/Bangazon/Views/PaymentTypes/Index.cshtml
@@ -24,14 +24,14 @@
             <th>
                 @Html.DisplayNameFor(model => model.User)
             </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Active)
-            </th>
+          
             <th></th>
         </tr>
     </thead>
+    
     <tbody>
 @foreach (var item in Model) {
+  
         <tr>
             <td>
                 @Html.DisplayFor(modelItem => item.DateCreated)
@@ -45,15 +45,13 @@
             <td>
                 @Html.DisplayFor(modelItem => item.User.Id)
             </td>
+         
             <td>
-                @Html.DisplayFor(modelItem => item.Active)
-            </td>
-            <td>
-                <a asp-action="Edit" asp-route-id="@item.PaymentTypeId">Edit</a> |
-                <a asp-action="Details" asp-route-id="@item.PaymentTypeId">Details</a> |
+        
                 <a asp-action="Delete" asp-route-id="@item.PaymentTypeId">Delete</a>
             </td>
         </tr>
-}
+        
+    }
     </tbody>
 </table>


### PR DESCRIPTION
# Description

User's can delete Payment types associated with their account

# Related Tickets
https://trello.com/c/GjBRzFuz/8-8-users-can-delete-payment-type

# Fixes From Previous Ticket
* User's can no longer choose the active status when creating a payment type
   It defaults to to active when created 

* User's no longer have an affordance for **Details** or **Edit** when viewing all payment types

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# Testing Instructions

* Add/commit your current changes to your working branch

* Run **git checkout master**

* Run **git fetch --all**

* Run **git checkout damDeletePaymentType**

* If you don't already have it create `AppSettings.json` (in BangazonSite project) or edit it with the following code:
`{
  "Logging": {
    "LogLevel": {
      "Default": "Warning"
    }
  },
  "AllowedHosts": "*",
  "ConnectionStrings": {
    "DefaultConnection": "Server=localhost\\SQLEXPRESS;Database=BangazonSite;Trusted_Connection=True;"
  }
}`

* The `"DefaultConnection"` will be different for some people make sure that it references the SQL server running on your machine

- If you DON'T have seed data or the initial database, open Package Manager Console and run `Add-Migration` and `Update-Database` to add these.

* In Visual Studio click the green play button at the top that says **IIS Express** or **F5** to start the browser

* Your browser should load a url in the address bar that looks like this **https://localhost:44345** 

* If your not logged in and display a page that says **Welcome** and the following affordances:
     *Home
     *Register 
     *Login

* If don't have an account click on the **Register** affordance to create one otherwise just log in

* Once logged in the top right coner of the screen you should see something like **Hello email@youremailaddress.com**

* Click on your email address and this will take you to a screen to manage your account settings

* Click on **Payment Options** located on the left side of your screen

* If you already have payment types associated with your user you will directed to a screen displaying all of the user's payment types with an affordance to **Create New**

* If you don't have any payment types associated with your user you will be directed to a screen that says **No Types of Payment Associated With This Account Yet** with an affordance to **Add A New Payment Type?**

* Click on either of the two affordances to be directed to a form to fill out information about your payment type

* Once you input all the information correctly and click the create affordance you will be redirected back to a view of your payment types and you should see the payment type you just created

* You will need at least 2 payment types to test so go ahead an create another payment type

* Once you have two payment types open Visual Studio

* Because we can't delete a payment type associated with an order and we don't have any  orders with a `PaymentTypeId`  yet we will have to create one

*Create a new **SQL Query** and run `SELECT * FROM PaymentType` 

* In the **PaymentType** table look at the **Active** column to make sure to make sure the active status is true for the payment types you created (1 means active/0 means inactive)

* In the **PaymentType** table look at the **PaymentTypeId** column and choose an id from one of the payment types you just created your going to need that  to create an **Order** associated with that payment type

* **BEFORE YOU RUN THIS**  Change the `UserId` to match your user and `PaymentTypeId` to match one of the payment types you just created
 `INSERT INTO "Order" (DateCreated, DateCompleted, UserId, PaymentTypeId)
VALUES('2020-09-19 12:34:36', Null, '37e73a75-7687-4a78-9860-4693ab1112d6', '20')` 

* Once you run the query from above run this **SQL Query**  `SELECT * FROM Order`  to make sure that you now have one payment type associated with an order

* Now go back to your browser and click the **Delete** affordance 

* You will be directed to a delete confirmation page 

* Click **Delete**

* Repeat the same process for the other payment type

* After that you will be directed back the view of all payment types where you should see you have no payment types associated with your account

* Open visual studio and run `SELECT * FROM PaymentType`

* You should see that the payment type that is associated with the order is still in the database but it's active status has changed from true to false while the payment type not associated with an order has been deleted from the database


# The Other Scenario
* If for some reason you have a Payment type Not associated with an order that has an active status of false 
it will not be displayed in the view of all payment types and cannot be deleted from browser. It can only be deleted by sql query

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
